### PR TITLE
feat: switch to product abstract as response object

### DIFF
--- a/src/main/java/io/github/onecx/product/store/rs/internal/mappers/ProductMapper.java
+++ b/src/main/java/io/github/onecx/product/store/rs/internal/mappers/ProductMapper.java
@@ -40,7 +40,7 @@ public interface ProductMapper {
     @Mapping(target = "removeStreamItem", ignore = true)
     ProductPageResultDTO mapPageResult(PageResult<Product> page);
 
-    ProductPageItemDTO mapPageItem(Product data);
+    ProductAbstractDTO mapProductAbstract(Product data);
 
     @Mapping(target = "removeClassificationsItem", ignore = true)
     ProductDTO map(Product data);

--- a/src/main/openapi/onecx-product-store-internal.yaml
+++ b/src/main/openapi/onecx-product-store-internal.yaml
@@ -183,7 +183,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
+                $ref: '#/components/schemas/ProductPageResult'
         "400":
           description: Bad request
           content:
@@ -286,39 +286,7 @@ components:
         stream:
           type: array
           items:
-            $ref: '#/components/schemas/ProductPageItem'
-    ProductPageItem:
-      type: object
-      properties:
-        id:
-          type: string
-        creationDate:
-          $ref: '#/components/schemas/OffsetDateTime'
-        creationUser:
-          type: string
-        modificationDate:
-          $ref: '#/components/schemas/OffsetDateTime'
-        modificationUser:
-          type: string
-        modificationCount:
-          format: int32
-          type: integer
-        name:
-          type: string
-        operator:
-          type: boolean
-        version:
-          type: string
-        description:
-          type: string
-        imageUrl:
-          type: string
-        basePath:
-          type: string
-        displayName:
-          type: string
-        iconName:
-          type: string
+            $ref: '#/components/schemas/Product'
     ProductSearchCriteria:
       type: object
       properties:

--- a/src/main/openapi/onecx-product-store-internal.yaml
+++ b/src/main/openapi/onecx-product-store-internal.yaml
@@ -183,7 +183,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Product'
+                $ref: '#/components/schemas/ProductPageResult'
         "400":
           description: Bad request
           content:
@@ -286,8 +286,8 @@ components:
         stream:
           type: array
           items:
-            $ref: '#/components/schemas/ProductPageItem'
-    ProductPageItem:
+            $ref: '#/components/schemas/ProductAbstract'
+    ProductAbstract:
       type: object
       properties:
         id:

--- a/src/main/openapi/onecx-product-store-internal.yaml
+++ b/src/main/openapi/onecx-product-store-internal.yaml
@@ -183,7 +183,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductPageResult'
+                $ref: '#/components/schemas/Product'
         "400":
           description: Bad request
           content:

--- a/src/main/openapi/onecx-product-store-internal.yaml
+++ b/src/main/openapi/onecx-product-store-internal.yaml
@@ -183,7 +183,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/ProductPageResult'
+                $ref: '#/components/schemas/Product'
         "400":
           description: Bad request
           content:
@@ -286,7 +286,39 @@ components:
         stream:
           type: array
           items:
-            $ref: '#/components/schemas/Product'
+            $ref: '#/components/schemas/ProductPageItem'
+    ProductPageItem:
+      type: object
+      properties:
+        id:
+          type: string
+        creationDate:
+          $ref: '#/components/schemas/OffsetDateTime'
+        creationUser:
+          type: string
+        modificationDate:
+          $ref: '#/components/schemas/OffsetDateTime'
+        modificationUser:
+          type: string
+        modificationCount:
+          format: int32
+          type: integer
+        name:
+          type: string
+        operator:
+          type: boolean
+        version:
+          type: string
+        description:
+          type: string
+        imageUrl:
+          type: string
+        basePath:
+          type: string
+        displayName:
+          type: string
+        iconName:
+          type: string
     ProductSearchCriteria:
       type: object
       properties:


### PR DESCRIPTION
Returning 'ProductAbstract' instead of  'ProductPageItem' (minor adjustment) in OpenAPI Spec File & mapper interface